### PR TITLE
Build cleanup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ django-safemigrate: Safely run migrations before deployment
 
 |
 
-django-safemigrate add a ``safemigrate`` command to Django
+django-safemigrate adds a ``safemigrate`` command to Django
 to allow for safely running a migration command when deploying.
 
 Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,14 @@
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+
 [tool.poetry]
 name = "django-safemigrate"
 version = "1.0"
 description = "Safely run migrations before deployment"
 authors = ["Ryan Hiebert <ryan@aspiredu.com>"]
-license = 'MIT'
+license = "MIT"
+readme = "README.rst"
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
Support PEP 518 and PEP 517 to specify the build system as poetry. Add the `readme` key, which populates the long_description used by PyPI. Fix a typo in the README.