### PR TITLE
Rework migration safety options

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,23 @@
+2.0 (TBD)
++++++++++
+
+* The valid values for ``safe`` are:
+
+  * ``Safe.before_deploy``
+  * ``Safe.after_deploy``
+  * ``Safe.always``
+
+  Import with ``from django_safemigrate import Safe``.
+  ``True`` is now ``Safe.before_deploy``,
+  and ``False`` is now ``Safe.after_deploy``.
+* The default safety marking, when unspecified,
+  is now ``Safe.after_deploy``, instead of ``Safe.before_deploy``.
+* ``Safe.always`` allows for migrations that may be run
+  either before or after deployment,
+  because they don't require any database changes.
+* Multiple dependent ``Safe.after_deploy`` migrations do not block deployment
+  as long as there are no dependent ``Safe.before_deploy`` migrations.
+
 1.0 (2019-01-13)
 ++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -36,32 +36,64 @@ Install ``django-safemigrate``, then add this to the
         "django_safemigrate.apps.SafeMigrateConfig",
     ]
 
-Then mark any migration that should not be run
+Then mark any migration that may be run
 during a pre-deployment stage,
-such as a migration to remove a column.
+such as a migration to add a column.
 
 .. code-block:: python
 
+    from django_safemigrate import Safe
+
     class Migration(migrations.Migration):
-        safe = False
+        safe = Safe.before_deploy
 
 At this point you can run the ``safemigrate`` Django command
-to run the migrations, and the unsafe migrations will not run.
+to run the migrations, and only these migrations will run.
+However, if migrations that are not safe to run before
+the code is deployed are dependencies of this migration,
+then these migrations will be blocked, and the safemigrate
+command will fail with an error.
+
 When the code is fully deployed, just run the normal ``migrate``
 Django command, which still functions normally.
-
 For example, you could add the command to the release phase
 for your Heroku app, and the safe migrations will be run
 automatically when the new release is promoted.
 
+Safety Options
+==============
+
+There are three options for the value of the
+``safe`` property of the migration.
+
+* ``Safe.before_deploy``
+
+  This migration is only safe to run before the code change is deployed.
+  For example, a migration that adds a new field to a model.
+
+* ``Safe.after_deploy``
+
+  This migration is only safe to run after the code change is deployed.
+  This is the default that is applied if no ``safe`` property is given.
+  For example, a migration that removes a field from a model.
+
+* ``Safe.always``
+
+  This migration is safe to run before *and* after
+  the code change is deployed.
+  For example, a migration that changes the ``help_text`` of a field.
+
 Nonstrict Mode
 ==============
 
-Under normal operation, if there are migrations that depend
-on any migration that is marked as unsafe,
+Under normal operation, if there are migrations
+that must run before the deployment that depend
+on any migration that is marked to run after deployment
+(or is not marked),
 the command will raise an error to indicate
-that there are unsafe migrations that
-should have already been run, but have not been.
+that there are protected migrations that
+should have already been run, but have not been,
+and are blocking migrations that are expected to run.
 
 In development, however, it is common that these
 would accumulate between developers,

--- a/src/django_safemigrate/__init__.py
+++ b/src/django_safemigrate/__init__.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class Safe(Enum):
+    always = "always"
+    before_deploy = "before_deploy"
+    after_deploy = "after_deploy"


### PR DESCRIPTION
Create an enum of the valid values of the ``safe`` property. The current True and False values now map to ``Safe.before_deploy`` and ``Safe.after_deploy``. The default, if unspecified, is now ``Safe.after_deploy``. Multiple ``Safe.after_deploy`` migrations may be dependent on each other without blocking the migration. Add ``Safe.always`` that can run either before or after the deployment, so that it runs before the deployment if possible, but can be delayed until after without blocking the deployment.

Fix #5 