### PR TITLE
Enforce that the safe property must be valid

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,7 +17,7 @@
   because they don't require any database changes.
 * Multiple dependent ``Safe.after_deploy`` migrations do not block deployment
   as long as there are no dependent ``Safe.before_deploy`` migrations.
-* Checks that any given value of safe is valid.
+* Enforce that any given value of safe is valid.
 
 1.0 (2019-01-13)
 ++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,7 @@
   because they don't require any database changes.
 * Multiple dependent ``Safe.after_deploy`` migrations do not block deployment
   as long as there are no dependent ``Safe.before_deploy`` migrations.
+* Checks that any given value of safe is valid.
 
 1.0 (2019-01-13)
 ++++++++++++++++

--- a/src/django_safemigrate/management/commands/safemigrate.py
+++ b/src/django_safemigrate/management/commands/safemigrate.py
@@ -45,6 +45,19 @@ class Command(migrate.Command):
 
         # Pull the migrations into a new list
         migrations = [migration for migration, backward in plan]
+
+        # Check for invalid safe properties
+        invalid = [
+            migration for migration in migrations if safety(migration) not in Safe
+        ]
+        if invalid:
+            self.stdout.write(self.style.MIGRATE_HEADING("Invalid migrations:"))
+            for migration in invalid:
+                self.stdout.write(f"  {migration.app_label}.{migration.name}")
+            raise CommandError(
+                "Aborting due to migrations with invalid safe properties."
+            )
+
         protected = [
             migration
             for migration in migrations

--- a/tests/safemigrate_test.py
+++ b/tests/safemigrate_test.py
@@ -250,3 +250,15 @@ class TestSafeMigrate:
         ]
         receiver(plan=plan)
         assert len(plan) == 1
+
+    def test_string_invalid(self, receiver):
+        """Invalid settings of the safe property will raise an error."""
+        plan = [(Migration("spam", "0001_initial", safe="before_deploy"), False)]
+        with pytest.raises(CommandError):
+            receiver(plan=plan)
+
+    def test_boolean_invalid(self, receiver):
+        """Booleans are invalid for the safe property."""
+        plan = [(Migration("spam", "0001_initial", safe=False), False)]
+        with pytest.raises(CommandError):
+            receiver(plan=plan)


### PR DESCRIPTION
It is acceptable for the safe property to not be given, and get the default. However, if the safe property is given, then it must be set correctly. Enforce this by ensuring that the value we will use is part of the Safe enum.

Fix #8 