### PR TITLE
Add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+-   id: check
+    name: Check migrations safety
+    description: Ensure that all local migrations have been marked for safety.
+    entry: safemigrate-check
+    language: python
+    files: migrations/\d{4}_.+\.py$
+    types: [file, python, text]
+    stages: [pre-commit, pre-merge-commit, pre-push, manual]
+    pass_filenames: true

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,8 @@
+4.1 (2023-09-13)
+++++++++++++++++
+
+* Add a pre-commit hook to ensure migrations have a safe atrribute.
+
 4.0 (2022-10-07)
 ++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,26 @@ There are three options for the value of the
   the code change is deployed.
   For example, a migration that changes the ``help_text`` of a field.
 
+Pre-commit Hook
+===============
+
+To get the most from django-safemigrate,
+it is important to make sure that all migrations
+are marked with the appropriate ``safe`` value.
+To help with this, we provide a hook for use with ``pre-commit``.
+`Install and configure pre-commit`_,
+then add this to the ``repos`` key of your ``.pre-commit-config.yaml``:
+
+.. code-block:: yaml
+
+    repos:
+        -   repo: https://github.com/aspiredu/django-safemigrate
+        rev: 4.1
+        hooks:
+        -   id: check
+
+.. _Install and configure pre-commit: https://pre-commit.com/
+
 Nonstrict Mode
 ==============
 

--- a/README.rst
+++ b/README.rst
@@ -157,7 +157,7 @@ To publish a new version:
 
 1. Find and replace all instances of the previous version with the new version.
 2. Commit and push that to origin.
-3. Tag the commit with the new version ``get tag 1.0`` and push that to origin.
+3. Tag the commit with the new version ``git tag 1.0`` and push that to origin.
 4. Create the
    `new release <https://github.com/aspiredu/django-safemigrate/releases/new>`_
    on GitHub.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ show_missing = true
 
 [tool.poetry]
 name = "django-safemigrate"
-version = "4.0"
+version = "4.1"
 description = "Safely run migrations before deployment"
 authors = ["Ryan Hiebert <ryan@aspiredu.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,6 @@ django = ">=3.2,<5.0"
 
 [tool.poetry.dev-dependencies]
 tox = "*"
+
+[tool.poetry.plugins."console_scripts"]
+"safemigrate-check" = "django_safemigrate.check:main"

--- a/src/django_safemigrate/check.py
+++ b/src/django_safemigrate/check.py
@@ -1,0 +1,56 @@
+"""
+Ensure migrations are using django_safemigrate.
+
+This is fairly rudimentary and won't work if the class doesn't
+explicitly inherit from ``Migration``.
+"""
+import re
+import sys
+
+MIGRATION_PATTERN = re.compile(r"class\s+(?P<MigrationClass>\w+)\s?\(.*Migration\):")
+
+MISSING_SAFE_MESSAGE = (
+    "{file_path}: {migration_class} is missing the 'safe' attribute.\n"
+)
+FAILURE_MESSAGE = (
+    "\n"
+    "Add the following to the migration class:\n"
+    "\n"
+    "from django_safemigrate import Safe\n"
+    "class Migration(migrations.Migration):\n"
+    "    safe = Safe.before_deploy\n"
+    "\n"
+    "You can also use the following:\n"
+    "    safe = Safe.always\n"
+    "    safe = Safe.after_deploy\n"
+    "\n"
+)
+
+
+def validate_migrations(files):
+    success = True
+    for file_path in files:
+        with open(file_path) as f:
+            content = f.read()
+
+        match = MIGRATION_PATTERN.search(content)
+        if match:
+            migration_class = match.group("MigrationClass")
+            if "safe = Safe." not in content:
+                success = False
+                sys.stdout.write(
+                    MISSING_SAFE_MESSAGE.format(
+                        file_path=file_path, migration_class=migration_class
+                    )
+                )
+    if not success:
+        sys.stdout.write(FAILURE_MESSAGE)
+    return success
+
+
+def main():  # pragma: no cover
+    sys.exit(0 if validate_migrations(sys.argv[1:]) else 1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
Check the migrations files in the current repository and ensure that they all have a `safe` property defined. While we can think of easy ways to break this implementation, for all the use-cases I've had this covers it quite nicely so I think it's worth merging even if its rough.

Tim Schilling put an initial sketch of this in https://github.com/aspiredu/django-safemigrate/issues/39 and I was able to modify it for use in a precommit hook without difficulty. The modifications were made to tailor it to the environment of pre-commit, where file names are passed to the command as arguments. This allows pre-commit to only need to run the checks incrementally for the affected files for new commits.

Fix #39 