### PR TITLE
Update Django versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: 1.13.0
     hooks:
     -   id: django-upgrade
-        args: [--target-version, "3.2"]
+        args: [--target-version, "4.2"]
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,9 @@
 Pending
 *******
 
+* Add support for Django 5.1.
+* Drop support for Django 3.2, 4.0, 4.1.
+
 4.3 (2024-03-28)
 ++++++++++++++++
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ readme = "README.rst"
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-django = ">=3.2"
+django = ">=4.2"
 
 [tool.poetry.dev-dependencies]
 tox = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,17 @@
 [tox]
 isolated_build = True
 envlist =
-    py{38,39,310}-dj32
-    py{38,39,310}-dj40
-    py{38,39,310,311}-dj41
     py{38,39,310,311,312}-dj42
     py{310,311,312}-dj50
+    py{310,311,312}-dj51
     py{310,311,312}-djmain
 
 [testenv]
 pip_pre = True
 deps =
-    dj32: django~=3.2.0
-    dj40: django~=4.0.0
-    dj41: django~=4.1.0
     dj42: django~=4.2.0
     dj50: django~=5.0.0
+    dj51: django~=5.1.0
     djmain: https://github.com/django/django/archive/main.tar.gz
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ pip_pre = True
 deps =
     dj42: django~=4.2.0
     dj50: django~=5.0.0
-    dj51: django~=5.1.0
+    dj51: django>=5.1,<5.2
     djmain: https://github.com/django/django/archive/main.tar.gz
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ pip_pre = True
 deps =
     dj42: django~=4.2.0
     dj50: django~=5.0.0
-    dj51: django>=5.1,<5.2
+    dj51: django~=5.1b
     djmain: https://github.com/django/django/archive/main.tar.gz
     pytest
     pytest-cov


### PR DESCRIPTION
- Remove unsupported versions of Django.
- Specify Django 5.1 in the test suite.
- Upgrade the dependencies.