### PR TITLE
Clean up test configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,11 +53,8 @@ jobs:
 
       - name: Run tox
         env:
-          DB_BACKEND: mysql
-          DB_USER: root
-          DB_PASSWORD: django_safemigrate
-          DB_HOST: 127.0.0.1
-          DB_PORT: 3306
+          DB: mysql
+          DATABASE_URL: "mysql://root:django_safemigrate@127.0.0.1/django_safemigrate"
         run: |
           tox
           python -m coverage combine
@@ -81,15 +78,15 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-        database: [postgresql]
+        database: [pg2]
         # Add psycopg3 to our matrix for modern python versions
         include:
             - python-version: '3.10'
-              database: psycopg3
+              database: pg3
             - python-version: '3.11'
-              database: psycopg3
+              database: pg3
             - python-version: '3.12'
-              database: psycopg3
+              database: pg3
 
     services:
       postgres:
@@ -134,9 +131,8 @@ jobs:
 
       - name: Run tox
         env:
-          DB_BACKEND: ${{ matrix.database }}
-          DB_HOST: localhost
-          DB_PORT: 5432
+          DB: ${{ matrix.database }}
+          DATABASE_URL: "postgresql://django_safemigrate:django_safemigrate@localhost/django_safemigrate"
         run: |
           tox
           python -m coverage combine
@@ -190,8 +186,8 @@ jobs:
 
       - name: Run tox
         env:
-          DB_BACKEND: sqlite3
-          DB_NAME: ":memory:"
+          DB: sqlite
+          DATABASE_URL: "sqlite:///:memory:"
         run: |
           tox
           python -m coverage combine

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ db.sqlite3
 htmlcov/
 dist/
 .tox/
+/venv/

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Install ``django-safemigrate``, then add this to the
 
     INSTALLED_APPS = [
         # ...
-        "django_safemigrate.apps.SafeMigrateConfig",
+        "django_safemigrate",
     ]
 
 Then mark any migration that may be run

--- a/tests/testproject/settings.py
+++ b/tests/testproject/settings.py
@@ -1,4 +1,5 @@
 import os
+import dj_database_url
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SECRET_KEY = "02^5l2jh+t-)3#+9!7&^5n0c#&o(ararue&=gj(*b02pk)i9(#"
@@ -11,20 +12,8 @@ USE_TZ = True
 INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",
-    "django_safemigrate.apps.SafeMigrateConfig",
+    "django_safemigrate",
 ]
 MIDDLEWARE = []
 ROOT_URLCONF = "testproject.urls"
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.{}".format(os.getenv("DB_BACKEND", "sqlite3")),
-        "NAME": os.getenv("DB_NAME", ":memory:"),
-        "USER": os.getenv("DB_USER"),
-        "PASSWORD": os.getenv("DB_PASSWORD"),
-        "HOST": os.getenv("DB_HOST", ""),
-        "PORT": os.getenv("DB_PORT", ""),
-        "TEST": {
-            "USER": "default_test",
-        },
-    },
-}
+DATABASES = {"default": dj_database_url.config(default="sqlite:///:memory:")}

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 isolated_build = True
 envlist =
     py{38,39,310,311,312}-dj42-sqlite
-    py{310,311,312}-dj50-{sqlite,postgresql,psycopg3,mysql}
+    py{310,311,312}-dj50-{sqlite,pg2,pg3,mysql}
     py{310,311,312}-dj51-sqlite
     py{310,311,312}-djmain-sqlite
 
@@ -17,48 +17,19 @@ deps =
     pytest-cov
     pytest-django
     pytest-mock
-    postgresql: psycopg2-binary
-    psycopg3: psycopg[binary]
+    dj-database-url
+    pg2: psycopg2-binary
+    pg3: psycopg[binary]
     mysql: mysqlclient
-passenv =
-    CI
-    GITHUB_*
-    DB_BACKEND
-    DB_NAME
-    DB_USER
-    DB_PASSWORD
-    DB_HOST
 setenv =
     PYTHONPATH = {toxinidir}
     PYTHONWARNINGS = d
-    DB_NAME = {env:DB_NAME:django_safemigrate}
-    DB_USER = {env:DB_USER:django_safemigrate}
-    DB_HOST = {env:DB_HOST:localhost}
-    DB_PASSWORD =  {env:DB_PASSWORD:django_safemigrate}
     DJANGO_SETTINGS_MODULE = tests.testproject.settings
+    pg2,pg3: DATABASE_URL = {env:DATABASE_URL:postgresql://django_safemigrate:django_safemigrate@localhost/django_safemigrate}
+    mysql: DATABASE_URL = {env:DATABASE_URL:mysql://django_safemigrate:django_safemigrate@127.0.0.1/django_safemigrate}
+    sqlite: DATABASE_URL = {env:DATABASE_URL:sqlite:///:memory:}
 commands =
     python -m coverage run -m pytest {posargs}
-
-
-[testenv:py{38,39,310,311,312}-dj{42,50,51,main}-{postgresql,psycopg3}]
-setenv =
-    {[testenv]setenv}
-    DB_BACKEND = postgresql
-    DB_PORT = {env:DB_PORT:5432}
-
-
-[testenv:py{38,39,310,311,312}-dj{42,50,51,main}-mysql]
-setenv =
-    {[testenv]setenv}
-    DB_BACKEND = mysql
-    DB_PORT = {env:DB_PORT:3306}
-
-
-[testenv:py{38,39,310,311,312}-dj{42,50,51,main}-sqlite]
-setenv =
-    {[testenv]setenv}
-    DB_BACKEND = sqlite3
-    DB_NAME = ":memory:
 
 [gh-actions]
 python =
@@ -69,8 +40,8 @@ python =
     3.12: py312
 
 [gh-actions:env]
-DB_BACKEND =
+DB =
     mysql: mysql
-    postgresql: postgresql
-    psycopg3: psycopg3
-    sqlite3: sqlite
+    pg2: pg2
+    pg3: pg3
+    sqlite: sqlite


### PR DESCRIPTION
* Use dj_database_url to simplify the database environment variables
* Give up purity and use `django_safemigrate` in `INSTALLED_APPS` instead of AppConfig
* Use `pg2` and `pg3` as the factor names for psycopg versions (bikeshedding for sure, and arguably incorrect versus `psycopg2` and `psycopg`)
* Stop setting `passenv` in tox, none of those are needed when we're using `setenv`
* Use factors in `setenv` like we do with deps to do conditional setting of environment variables

Pulled out of #59 