### PR TITLE
Write detected migrations even when all are safe

### DIFF
--- a/src/django_safemigrate/management/commands/safemigrate.py
+++ b/src/django_safemigrate/management/commands/safemigrate.py
@@ -2,6 +2,7 @@
 
 Migration safety is enforced by a pre_migrate signal receiver.
 """
+
 from __future__ import annotations
 
 from enum import Enum
@@ -133,7 +134,8 @@ class Command(migrate.Command):
         ready, protected = filter_migrations(migrations)
 
         if not protected:
-            return  # No migrations to protect.
+            self.detect(migrations)
+            return  # Run all the migrations
 
         # Display the migrations that are protected
         self.stdout.write(self.style.MIGRATE_HEADING("Protected migrations:"))
@@ -175,16 +177,20 @@ class Command(migrate.Command):
 
         # Only mark migrations as detected if not faking
         if not self.fake:
-            # The detection datetime is what's used to determine if an
-            # after_deploy() with a delay can be migrated or not.
-            for migration in migrations:
-                SafeMigration.objects.get_or_create(
-                    app=migration.app_label, name=migration.name
-                )
+            self.detect(migrations)
 
         # Swap out the items in the plan with the safe migrations.
         # None are backward, so we can always set backward to False.
         plan[:] = [(migration, False) for migration in ready]
+
+    def detect(self, migrations):
+        """Detect and record migrations to the database."""
+        # The detection datetime is what's used to determine if an
+        # after_deploy() with a delay can be migrated or not.
+        for migration in migrations:
+            SafeMigration.objects.get_or_create(
+                app=migration.app_label, name=migration.name
+            )
 
     def delayed(self, migrations):
         """Handle delayed migrations."""

--- a/tests/safemigrate_test.py
+++ b/tests/safemigrate_test.py
@@ -610,6 +610,24 @@ class TestSafeMigrate:
         assert SafeMigration.objects.filter(detected__gt=existing.detected).count() == 2
 
 
+    def test_migrations_are_detected_when_no_delays(self, receiver):
+        """Migrations should be marked as detected when there are no delays."""
+        plan = [
+            (Migration("spam", "0001_initial", safe=Safe.before_deploy()), False),
+            (
+                Migration(
+                    "spam",
+                    "0002_followup",
+                    safe=Safe.always(),
+                    dependencies=[("spam", "0001_initial")],
+                ),
+                False,
+            ),
+        ]
+        receiver(plan=plan)
+        assert SafeMigration.objects.count() == 2
+
+
 class TestCheckMissingSafe:
     """
     Test the check command for migrations


### PR DESCRIPTION
I believe this is what was intended, that any migration that doesn't block, isn't faked, and isn't in "disabled" mode, will record all the seen migrations. This catches the case where we exit early because we know that there are no protected migrations.