### PR TITLE
Rename enums for clarity and pep8

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ Pending
   * ``Safe.always()``
 * Add support for allowing a ``Safe.after_deploy(delay=timedelta())``
   migration to be migrated after the delay has passed.
+* Rename internal enums for clarity and PEP8.
 
 4.3 (2024-03-28)
 ++++++++++++++++

--- a/src/django_safemigrate/__init__.py
+++ b/src/django_safemigrate/__init__.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from enum import Enum
 
 
-class SafeEnum(Enum):
+class When(Enum):
     always = "always"
     before_deploy = "before_deploy"
     after_deploy = "after_deploy"
@@ -13,17 +13,17 @@ class SafeEnum(Enum):
 
 @dataclass
 class Safe:
-    safe: SafeEnum
+    when: When
     delay: timedelta | None = None
 
     @classmethod
     def always(cls):
-        return cls(safe=SafeEnum.always)
+        return cls(when=When.always)
 
     @classmethod
     def before_deploy(cls):
-        return cls(safe=SafeEnum.before_deploy)
+        return cls(when=When.before_deploy)
 
     @classmethod
     def after_deploy(cls, *, delay: timedelta = None):
-        return cls(safe=SafeEnum.after_deploy, delay=delay)
+        return cls(when=When.after_deploy, delay=delay)


### PR DESCRIPTION
This one is not urgent. IMO, it would be fine to release this in a minor version upgrade.

PEP 8 spoke that we should use ALL_CAPS for enum values, but I was too stubborn to get on board. In this I hope to lower my stubbornness by switching this in these internal APIs. And rename our enums to have a bit clearer semantic meaning that I hope will be easier to digest.