### PR TITLE
Add compatibility with documented prior API

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ Pending
 * Add support for Django 5.1.
 * Drop support for Django 3.2, 4.0, 4.1.
 * Convert ``Safe`` to be a custom class rather than an ``Enum``.
-* The valid values for ``safe`` are:
+* The preferred values for ``safe`` are now methods:
 
   * ``Safe.before_deploy()``
   * ``Safe.after_deploy()``

--- a/src/django_safemigrate/management/commands/safemigrate.py
+++ b/src/django_safemigrate/management/commands/safemigrate.py
@@ -27,7 +27,9 @@ class Mode(Enum):
 
 def safety(migration: Migration):
     """Determine the safety status of a migration."""
-    return getattr(migration, "safe", Safe.always())
+    safe = getattr(migration, "safe", Safe.always())
+    callables = [Safe.before_deploy, Safe.after_deploy, Safe.always]
+    return safe() if safe in callables else safe
 
 
 def safemigrate_mode():

--- a/tests/safemigrate_test.py
+++ b/tests/safemigrate_test.py
@@ -61,6 +61,17 @@ class TestSafeMigrate:
         receiver(plan=plan)
         assert len(plan) == 1
 
+    def test_callable_compat(self, receiver):
+        """Understand and do not throw an error when using compatibility syntax."""
+        # The plan items aren't dependencies of each other.
+        plan = [
+            (Migration(safe=Safe.before_deploy), False),
+            (Migration(safe=Safe.always), False),
+            (Migration(safe=Safe.after_deploy), False),
+        ]
+        receiver(plan=plan)
+        assert len(plan) == 2
+
     def test_backward(self, receiver):
         """It should fail to run backward."""
         plan = [(Migration(), True)]


### PR DESCRIPTION
In addition to just providing compatibility with the old API, I want the old API to still be the preferred documented API, so I changed some language in the history and reverted the readme examples to the old api.

Fix #54 